### PR TITLE
Change `const` to `var`

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function mustNotSetLocation(req){
 }
 
 function setUrl(req, res){
-  const href = req.protocol + '://' + req.get('host') + req.originalUrl
+  var href = req.protocol + '://' + req.get('host') + req.originalUrl
   return exports.default = global.Location = req.Location = {
     href: href,
     protocol: getProtocol(href),


### PR DESCRIPTION
In order to successfully run in older browser environments that do not support the `const` keyword, I changed the one and only usage of it to `var` in order for it to work.